### PR TITLE
Clean up custom baked model handling, fixes issues with ModernFix dynamic resources

### DIFF
--- a/src/main/java/com/telepathicgrunt/the_bumblezone/client/BumblezoneClient.java
+++ b/src/main/java/com/telepathicgrunt/the_bumblezone/client/BumblezoneClient.java
@@ -70,9 +70,7 @@ public class BumblezoneClient {
         modEventBus.addListener(IncenseCandleColoring::registerBlockColors);
         modEventBus.addListener(IncenseCandleColoring::registerItemColors);
         modEventBus.addListener(PorousHoneycombBlockModel::registerModelLoaders);
-        modEventBus.addListener(PorousHoneycombBlockModel::onBakingCompleted);
         modEventBus.addListener(EmptyHoneycombBroodBlockModel::registerModelLoaders);
-        modEventBus.addListener(EmptyHoneycombBroodBlockModel::onBakingCompleted);
         forgeBus.addListener((TickEvent.ClientTickEvent event) -> {
             if (event.phase == TickEvent.Phase.END) {
                 StinglessBeeHelmet.decrementHighlightingCounter(Minecraft.getInstance().player);

--- a/src/main/java/com/telepathicgrunt/the_bumblezone/client/bakedmodel/EmptyHoneycombBroodLoader.java
+++ b/src/main/java/com/telepathicgrunt/the_bumblezone/client/bakedmodel/EmptyHoneycombBroodLoader.java
@@ -36,7 +36,7 @@ public class EmptyHoneycombBroodLoader implements IGeometryLoader<EmptyHoneycomb
         @Override
         public BakedModel bake(IGeometryBakingContext context, ModelBakery bakery, Function<Material, TextureAtlasSprite> spriteGetter, ModelState modelState, ItemOverrides overrides, ResourceLocation modelLocation)
         {
-            return new EmptyHoneycombBroodBlockModel(modelLocation, botLeft, botRight, topLeft, topRight, particle, side, front);
+            return new EmptyHoneycombBroodBlockModel(modelLocation, botLeft, botRight, topLeft, topRight, particle, side, front, spriteGetter);
         }
 
         @Override

--- a/src/main/java/com/telepathicgrunt/the_bumblezone/client/bakedmodel/PorousHoneycombLoader.java
+++ b/src/main/java/com/telepathicgrunt/the_bumblezone/client/bakedmodel/PorousHoneycombLoader.java
@@ -36,7 +36,7 @@ public class PorousHoneycombLoader implements IGeometryLoader<PorousHoneycombLoa
         @Override
         public BakedModel bake(IGeometryBakingContext context, ModelBakery bakery, Function<Material, TextureAtlasSprite> spriteGetter, ModelState modelState, ItemOverrides overrides, ResourceLocation modelLocation)
         {
-            return new PorousHoneycombBlockModel(modelLocation, botLeft, botRight, topLeft, topRight, particle, base);
+            return new PorousHoneycombBlockModel(modelLocation, botLeft, botRight, topLeft, topRight, particle, base, spriteGetter);
         }
 
         @Override


### PR DESCRIPTION
There is no documentation, but from experimenting it seems that the original reason for this awkward hack of adding models to a list and initializing them later was because you cannot use `getTextureAtlas` during model baking. However, Minecraft explicitly provides a texture getter function as a parameter to the `bake` function for this purpose. As such we can simply make use of that. This removes the need to iterate a list of already loaded models in `BakingCompleted` and therefore fixes issues when ModernFix's dynamic resources optimization is enabled (which does not load all models at startup).