### PR TITLE
Lootr integration

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     modCompileOnly("me.shedaniel:RoughlyEnoughItems-api:${rootProject.rei}")
     modCompileOnly("me.shedaniel:RoughlyEnoughItems-default-plugin:${rootProject.rei}")
     modCompileOnly("me.shedaniel.cloth:cloth-config-fabric:${rootProject.cloth_config}")
+    modRuntimeOnly("me.shedaniel.cloth:cloth-config-fabric:${rootProject.cloth_config}")
 
     modCompileOnly("maven.modrinth:projectile-damage-attribute:${rootProject.projectile_damage_attribute}-forge")
 

--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/HoneyCocoon.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/HoneyCocoon.java
@@ -3,6 +3,8 @@ package com.telepathicgrunt.the_bumblezone.blocks;
 import com.mojang.datafixers.util.Pair;
 import com.telepathicgrunt.the_bumblezone.blocks.blockentities.HoneyCocoonBlockEntity;
 import com.telepathicgrunt.the_bumblezone.items.recipes.ContainerCraftingRecipe;
+import com.telepathicgrunt.the_bumblezone.modcompat.LootrCompat;
+import com.telepathicgrunt.the_bumblezone.modcompat.ModChecker;
 import com.telepathicgrunt.the_bumblezone.modinit.BzBlockEntities;
 import com.telepathicgrunt.the_bumblezone.modinit.BzCriterias;
 import com.telepathicgrunt.the_bumblezone.modinit.BzFluids;
@@ -65,6 +67,8 @@ import java.util.List;
 
 public class HoneyCocoon extends BaseEntityBlock implements SimpleWaterloggedBlock {
     public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
+    public static final BooleanProperty IS_LOOT_CONTAINER = BooleanProperty.create("is_loot");
+
     protected final VoxelShape shape;
     public static final int waterDropDelay = 150;
 
@@ -76,7 +80,7 @@ public class HoneyCocoon extends BaseEntityBlock implements SimpleWaterloggedBlo
                 .noOcclusion()
                 .sound(SoundType.HONEY_BLOCK));
 
-        this.registerDefaultState(this.stateDefinition.any().setValue(WATERLOGGED, Boolean.FALSE));
+        this.registerDefaultState(this.stateDefinition.any().setValue(WATERLOGGED, Boolean.FALSE).setValue(IS_LOOT_CONTAINER, Boolean.FALSE));
 
         VoxelShape voxelshape = Block.box(1.0D, 1.0D, 1.0D, 15.0D, 14.0D, 15.0D);
         voxelshape = Shapes.or(voxelshape, Block.box(2.0D, 0.0D, 2.0D, 14.0D, 1.0D, 14.0D));
@@ -105,7 +109,7 @@ public class HoneyCocoon extends BaseEntityBlock implements SimpleWaterloggedBlo
      */
     @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
-        builder.add(WATERLOGGED);
+        builder.add(WATERLOGGED, IS_LOOT_CONTAINER);
     }
 
     /**
@@ -155,7 +159,7 @@ public class HoneyCocoon extends BaseEntityBlock implements SimpleWaterloggedBlo
         if(!blockState.getValue(WATERLOGGED)) {
             BlockEntity blockEntity = serverLevel.getBlockEntity(blockPos);
             if(blockEntity instanceof HoneyCocoonBlockEntity honeyCocoonBlockEntity) {
-                if (!honeyCocoonBlockEntity.isUnpackedLoottable()) {
+                if (!honeyCocoonBlockEntity.isUnpackedLoottable() || blockState.getValue(IS_LOOT_CONTAINER)) {
                     return;
                 }
 
@@ -224,7 +228,7 @@ public class HoneyCocoon extends BaseEntityBlock implements SimpleWaterloggedBlo
         if(blockState.getValue(WATERLOGGED)) {
             BlockEntity blockEntity = serverLevel.getBlockEntity(blockPos);
             if(blockEntity instanceof HoneyCocoonBlockEntity honeyCocoonBlockEntity) {
-                if (!honeyCocoonBlockEntity.isUnpackedLoottable()) {
+                if (!honeyCocoonBlockEntity.isUnpackedLoottable() || blockState.getValue(IS_LOOT_CONTAINER)) {
                     return;
                 }
 
@@ -272,7 +276,12 @@ public class HoneyCocoon extends BaseEntityBlock implements SimpleWaterloggedBlo
             return InteractionResult.SUCCESS;
         }
         else {
-            MenuProvider menuprovider = this.getMenuProvider(blockstate, world, position);
+            MenuProvider menuprovider;
+            if (ModChecker.lootrPresent) {
+                menuprovider = LootrCompat.getCocoonMenu((ServerPlayer)playerEntity, blockstate, world, position);
+            } else {
+                menuprovider = this.getMenuProvider(blockstate, world, position);
+            }
             if (menuprovider != null) {
                 playerEntity.openMenu(menuprovider);
             }

--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/HoneyCocoon.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/HoneyCocoon.java
@@ -276,10 +276,15 @@ public class HoneyCocoon extends BaseEntityBlock implements SimpleWaterloggedBlo
             return InteractionResult.SUCCESS;
         }
         else {
-            MenuProvider menuprovider;
+            MenuProvider menuprovider = null;
             if (ModChecker.lootrPresent) {
-                menuprovider = LootrCompat.getCocoonMenu((ServerPlayer)playerEntity, blockstate, world, position);
-            } else {
+                if (world.getBlockEntity(position) instanceof HoneyCocoonBlockEntity blockEntity && blockEntity.getLootTable() != null) {
+                    menuprovider = LootrCompat.getCocoonMenu((ServerPlayer) playerEntity, blockEntity);
+                }
+            }
+            // IDE never realizes `ModChecker.lootrPresent` changes to true so it always thinks menuprovider is null.
+            //noinspection ConstantValue
+            if (menuprovider == null) {
                 menuprovider = this.getMenuProvider(blockstate, world, position);
             }
             if (menuprovider != null) {

--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/blockentities/HoneyCocoonBlockEntity.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/blockentities/HoneyCocoonBlockEntity.java
@@ -59,7 +59,9 @@ public class HoneyCocoonBlockEntity extends BzRandomizableContainerBlockEntity {
         if (!this.tryLoadLootTable(compoundTag) && compoundTag.contains("Items", 9)) {
             ContainerHelper.loadAllItems(compoundTag, this.itemStacks);
         }
-        this.blockEntityUuid = compoundTag.getUUID("blockEntityUuid");
+        if (compoundTag.hasUUID("blockEntityUuid")) {
+            this.blockEntityUuid = compoundTag.getUUID("blockEntityUuid");
+        }
     }
 
     @Override

--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/blockentities/HoneyCocoonBlockEntity.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/blockentities/HoneyCocoonBlockEntity.java
@@ -1,6 +1,7 @@
 package com.telepathicgrunt.the_bumblezone.blocks.blockentities;
 
 import com.telepathicgrunt.the_bumblezone.blocks.HoneyCocoon;
+import com.telepathicgrunt.the_bumblezone.modcompat.ModChecker;
 import com.telepathicgrunt.the_bumblezone.modinit.BzBlockEntities;
 import com.telepathicgrunt.the_bumblezone.modinit.BzBlocks;
 import com.telepathicgrunt.the_bumblezone.modinit.BzFluids;
@@ -11,6 +12,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.ContainerHelper;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -19,11 +21,14 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.UUID;
 import java.util.stream.IntStream;
 
 public class HoneyCocoonBlockEntity extends BzRandomizableContainerBlockEntity {
     private NonNullList<ItemStack> itemStacks = NonNullList.withSize(18, ItemStack.EMPTY);
+    private UUID blockEntityUuid = null;
 
     protected HoneyCocoonBlockEntity(BlockEntityType<?> blockEntityType, BlockPos blockPos, BlockState blockState) {
         super(blockEntityType, blockPos, blockState);
@@ -54,6 +59,7 @@ public class HoneyCocoonBlockEntity extends BzRandomizableContainerBlockEntity {
         if (!this.tryLoadLootTable(compoundTag) && compoundTag.contains("Items", 9)) {
             ContainerHelper.loadAllItems(compoundTag, this.itemStacks);
         }
+        this.blockEntityUuid = compoundTag.getUUID("blockEntityUuid");
     }
 
     @Override
@@ -62,6 +68,7 @@ public class HoneyCocoonBlockEntity extends BzRandomizableContainerBlockEntity {
         if (!this.trySaveLootTable(tag)) {
             ContainerHelper.saveAllItems(tag, this.itemStacks);
         }
+        tag.putUUID("blockEntityUuid", this.getBlockEntityUuid());
     }
 
     @Override
@@ -105,6 +112,10 @@ public class HoneyCocoonBlockEntity extends BzRandomizableContainerBlockEntity {
 
     @Override
     public void unpackLootTable(Player player) {
+        if (ModChecker.lootrPresent) {
+            return;
+        }
+
         super.unpackLootTable(player);
 
         if (this.level != null) {
@@ -114,5 +125,22 @@ public class HoneyCocoonBlockEntity extends BzRandomizableContainerBlockEntity {
                 this.level.scheduleTick(this.worldPosition, blockState.getBlock(), HoneyCocoon.waterDropDelay);
             }
         }
+    }
+
+    public UUID getBlockEntityUuid () {
+        if (this.blockEntityUuid == null) {
+            this.blockEntityUuid = UUID.randomUUID();
+        }
+
+        return this.blockEntityUuid;
+    }
+
+    @Nullable
+    public ResourceLocation getLootTable () {
+        return this.lootTable;
+    }
+
+    public long getLootSeed () {
+        return this.lootTableSeed;
     }
 }

--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/LootrCompat.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/LootrCompat.java
@@ -1,0 +1,30 @@
+package com.telepathicgrunt.the_bumblezone.modcompat;
+
+import com.telepathicgrunt.the_bumblezone.blocks.blockentities.HoneyCocoonBlockEntity;
+import dev.architectury.injectables.annotations.ExpectPlatform;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.Container;
+import net.minecraft.world.MenuProvider;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import org.apache.commons.lang3.NotImplementedException;
+
+public class LootrCompat implements ModCompat {
+  public LootrCompat() {
+    // Keep at end so it is only set to true if no exceptions was thrown during setup
+    ModChecker.lootrPresent = true;
+  }
+
+  @ExpectPlatform
+  public static MenuProvider getCocoonMenu(ServerPlayer player, BlockState state, Level level, BlockPos position) {
+    throw new NotImplementedException("LootrCompat getCocoonMenu is not implemented!");
+  }
+
+  @ExpectPlatform
+  public static void unpackLootTable(HoneyCocoonBlockEntity blockEntity, Player player, Container inventory, ResourceLocation table, long seed) {
+    throw new NotImplementedException("LootrCompat unpackLootTable is not implemented!");
+  }
+}

--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/LootrCompat.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/LootrCompat.java
@@ -1,15 +1,16 @@
 package com.telepathicgrunt.the_bumblezone.modcompat;
 
 import com.telepathicgrunt.the_bumblezone.blocks.blockentities.HoneyCocoonBlockEntity;
+import com.telepathicgrunt.the_bumblezone.modinit.BzMenuTypes;
+import com.telepathicgrunt.the_bumblezone.screens.StrictChestMenu;
 import dev.architectury.injectables.annotations.ExpectPlatform;
-import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.MenuProvider;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.inventory.AbstractContainerMenu;
 import org.apache.commons.lang3.NotImplementedException;
 
 public class LootrCompat implements ModCompat {
@@ -19,12 +20,16 @@ public class LootrCompat implements ModCompat {
   }
 
   @ExpectPlatform
-  public static MenuProvider getCocoonMenu(ServerPlayer player, BlockState state, Level level, BlockPos position) {
+  public static MenuProvider getCocoonMenu(ServerPlayer player, HoneyCocoonBlockEntity blockEntity) {
     throw new NotImplementedException("LootrCompat getCocoonMenu is not implemented!");
   }
 
   @ExpectPlatform
   public static void unpackLootTable(HoneyCocoonBlockEntity blockEntity, Player player, Container inventory, ResourceLocation table, long seed) {
     throw new NotImplementedException("LootrCompat unpackLootTable is not implemented!");
+  }
+
+  public static AbstractContainerMenu menuBuilder(int id, Inventory inventory, Container container, int rows) {
+    return new StrictChestMenu(BzMenuTypes.STRICT_9x2.get(), id, inventory, container, rows);
   }
 }

--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/ModChecker.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/ModChecker.java
@@ -39,6 +39,7 @@ public class ModChecker {
 	public static boolean backpackedPresent = false;
 	public static boolean projectileDamageAttributePresent = false;
 	public static boolean jonnTrophiesPresent = false;
+	public static boolean lootrPresent = false;
 
 	/*
 	 * -- DO NOT TURN THE LAMBDAS INTO METHOD REFS. Method refs are not classloading safe. --

--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/ModChecker.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/ModChecker.java
@@ -72,6 +72,9 @@ public class ModChecker {
 
 			modid = "projectile_damage";
 			loadupModCompat(modid, () -> new ProjectileDamageAttributeCompat());
+
+			modid = "lootr";
+			loadupModCompat(modid, () -> new LootrCompat());
 		}
 		catch (Throwable e) {
 			printErrorToLogs("classloading " + modid + " and so, mod compat done afterwards broke");

--- a/fabric-base/build.gradle
+++ b/fabric-base/build.gradle
@@ -24,6 +24,9 @@ dependencies {
         force = true
     }
 
+    modCompileOnly("curse.maven:lootr_fabric-615106:${project.lootr_fabric_file_id}")
+    modRuntimeOnly("curse.maven:lootr_fabric-615106:${project.lootr_fabric_file_id}")
+
     modImplementation "maven.modrinth:midnightlib:${rootProject.midnightlib}"
 
     modCompileOnly "maven.modrinth:modmenu:${rootProject.mod_menu}"

--- a/fabric-base/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/fabricbase/LootrCompatImpl.java
+++ b/fabric-base/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/fabricbase/LootrCompatImpl.java
@@ -2,15 +2,12 @@ package com.telepathicgrunt.the_bumblezone.modcompat.fabricbase;
 
 import com.telepathicgrunt.the_bumblezone.blocks.blockentities.HoneyCocoonBlockEntity;
 import com.telepathicgrunt.the_bumblezone.modcompat.LootrCompat;
-import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
@@ -19,12 +16,8 @@ import net.minecraft.world.phys.Vec3;
 import net.zestyblaze.lootr.api.LootrAPI;
 
 public class LootrCompatImpl {
-  public static MenuProvider getCocoonMenu(ServerPlayer player, BlockState state, Level level, BlockPos position) {
-    if (level.getBlockEntity(position) instanceof HoneyCocoonBlockEntity blockEntity) {
-      return LootrAPI.getModdedMenu(blockEntity.getLevel(), blockEntity.getBlockEntityUuid(), blockEntity.getBlockPos(), player, blockEntity, (lootPlayer, inventory, table, seed) -> LootrCompat.unpackLootTable(blockEntity, lootPlayer, inventory, table, seed), blockEntity::getLootTable, blockEntity::getLootSeed);
-    }
-
-    return null;
+  public static MenuProvider getCocoonMenu(ServerPlayer player, HoneyCocoonBlockEntity blockEntity) {
+    return LootrAPI.getModdedMenu(blockEntity.getLevel(), blockEntity.getBlockEntityUuid(), blockEntity.getBlockPos(), player, blockEntity, (lootPlayer, inventory, table, seed) -> LootrCompat.unpackLootTable(blockEntity, lootPlayer, inventory, table, seed), blockEntity::getLootTable, blockEntity::getLootSeed, LootrCompat::menuBuilder);
   }
 
   public static void unpackLootTable(HoneyCocoonBlockEntity blockEntity, Player player, Container inventory, ResourceLocation table, long seed) {

--- a/fabric-base/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/fabricbase/LootrCompatImpl.java
+++ b/fabric-base/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/fabricbase/LootrCompatImpl.java
@@ -1,0 +1,46 @@
+package com.telepathicgrunt.the_bumblezone.modcompat.fabricbase;
+
+import com.telepathicgrunt.the_bumblezone.blocks.blockentities.HoneyCocoonBlockEntity;
+import com.telepathicgrunt.the_bumblezone.modcompat.LootrCompat;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.Container;
+import net.minecraft.world.MenuProvider;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.storage.loot.LootParams;
+import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.phys.Vec3;
+import net.zestyblaze.lootr.api.LootrAPI;
+
+public class LootrCompatImpl {
+  public static MenuProvider getCocoonMenu(ServerPlayer player, BlockState state, Level level, BlockPos position) {
+    if (level.getBlockEntity(position) instanceof HoneyCocoonBlockEntity blockEntity) {
+      return LootrAPI.getModdedMenu(blockEntity.getLevel(), blockEntity.getBlockEntityUuid(), blockEntity.getBlockPos(), player, blockEntity, (lootPlayer, inventory, table, seed) -> LootrCompat.unpackLootTable(blockEntity, lootPlayer, inventory, table, seed), blockEntity::getLootTable, blockEntity::getLootSeed);
+    }
+
+    return null;
+  }
+
+  public static void unpackLootTable(HoneyCocoonBlockEntity blockEntity, Player player, Container inventory, ResourceLocation table, long seed) {
+    if (table == null) {
+      LootrAPI.LOG.error("Unable to fill loot cocoon in " + blockEntity.getLevel().dimension() + " at " + blockEntity.getBlockPos() + " as the loot table was null.");
+      return;
+    }
+    LootTable loottable = blockEntity.getLevel().getServer().getLootData().getLootTable(table);
+    if (loottable == LootTable.EMPTY) {
+      LootrAPI.LOG.error("Unable to fill loot cocoon in " + blockEntity.getLevel().dimension() + " at " + blockEntity.getBlockPos() + " as the loot table '" + table + "' couldn't be resolved! Please search the loot table in `latest.log` to see if there are errors in loading.");
+      return;
+    }
+    LootParams.Builder builder = (new LootParams.Builder((ServerLevel) blockEntity.getLevel()).withParameter(LootContextParams.ORIGIN, Vec3.atCenterOf(blockEntity.getBlockPos())));
+    if (player != null) {
+      builder.withLuck(player.getLuck()).withParameter(LootContextParams.THIS_ENTITY, player);
+    }
+    loottable.fill(inventory, builder.create(LootContextParamSets.CHEST), LootrAPI.getLootSeed(seed));
+  }
+}

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     include("dev.onyxstudios.cardinal-components-api:cardinal-components-base:${rootProject.cardinal_components}")
     include("dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${rootProject.cardinal_components}")
 
+    modImplementation("me.shedaniel.cloth:cloth-config-fabric:${rootProject.cloth_config}")
     //modCompileOnly("com.github.CaffeineMC:sodium-fabric:${rootProject.sodium}")
     //modLocalRuntime("com.github.CaffeineMC:sodium-fabric:${rootProject.sodium}")
 

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -25,6 +25,9 @@ dependencies {
         force = true
     }
 
+    modCompileOnly("curse.maven:lootr_fabric-615106:${project.lootr_fabric_file_id}")
+    modRuntimeOnly("curse.maven:lootr_fabric-615106:${project.lootr_fabric_file_id}")
+
     modImplementation("maven.modrinth:midnightlib:${rootProject.midnightlib}")
 
     modCompileOnly("maven.modrinth:modmenu:${rootProject.mod_menu}")

--- a/fabric/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/fabric/LootrCompatImpl.java
+++ b/fabric/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/fabric/LootrCompatImpl.java
@@ -1,4 +1,4 @@
-package com.telepathicgrunt.the_bumblezone.modcompat.fabricbase;
+package com.telepathicgrunt.the_bumblezone.modcompat.fabric;
 
 import com.telepathicgrunt.the_bumblezone.blocks.blockentities.HoneyCocoonBlockEntity;
 import com.telepathicgrunt.the_bumblezone.modcompat.LootrCompat;

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     modCompileOnly("curse.maven:productive_bees-377897:${project.productivebees_file_id}")
     //modRuntimeOnly("curse.maven:productive_bees-377897:${project.productivebees_file_id}")
 
+    modCompileOnly("curse.maven:lootr-361276:${project.lootr_file_id}")
+    modRuntimeOnly("curse.maven:lootr-361276:${project.lootr_file_id}")
+
     modCompileOnly("curse.maven:pokecube_aio-285121:${project.pokecubeaio_version}")
 
     modCompileOnly("curse.maven:buzzier_bees-355458:${project.buzzier_bees_file_id}")

--- a/forge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/forge/LootrCompatImpl.java
+++ b/forge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/forge/LootrCompatImpl.java
@@ -19,12 +19,8 @@ import net.minecraft.world.phys.Vec3;
 import noobanidus.mods.lootr.api.LootrAPI;
 
 public class LootrCompatImpl {
-  public static MenuProvider getCocoonMenu(ServerPlayer player, BlockState state, Level level, BlockPos position) {
-    if (level.getBlockEntity(position) instanceof HoneyCocoonBlockEntity blockEntity) {
-      return LootrAPI.getModdedMenu(blockEntity.getLevel(), blockEntity.getBlockEntityUuid(), blockEntity.getBlockPos(), player, blockEntity, (lootPlayer, inventory, table, seed) -> LootrCompat.unpackLootTable(blockEntity, lootPlayer, inventory, table, seed), blockEntity::getLootTable, blockEntity::getLootSeed);
-    }
-
-    return null;
+  public static MenuProvider getCocoonMenu(ServerPlayer player, HoneyCocoonBlockEntity blockEntity) {
+      return LootrAPI.getModdedMenu(blockEntity.getLevel(), blockEntity.getBlockEntityUuid(), blockEntity.getBlockPos(), player, blockEntity, (lootPlayer, inventory, table, seed) -> LootrCompat.unpackLootTable(blockEntity, lootPlayer, inventory, table, seed), blockEntity::getLootTable, blockEntity::getLootSeed, LootrCompat::menuBuilder);
   }
 
   public static void unpackLootTable(HoneyCocoonBlockEntity blockEntity, Player player, Container inventory, ResourceLocation table, long seed) {

--- a/forge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/forge/LootrCompatImpl.java
+++ b/forge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/forge/LootrCompatImpl.java
@@ -1,0 +1,46 @@
+package com.telepathicgrunt.the_bumblezone.modcompat.forge;
+
+import com.telepathicgrunt.the_bumblezone.blocks.blockentities.HoneyCocoonBlockEntity;
+import com.telepathicgrunt.the_bumblezone.modcompat.LootrCompat;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.Container;
+import net.minecraft.world.MenuProvider;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.storage.loot.LootParams;
+import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.phys.Vec3;
+import noobanidus.mods.lootr.api.LootrAPI;
+
+public class LootrCompatImpl {
+  public static MenuProvider getCocoonMenu(ServerPlayer player, BlockState state, Level level, BlockPos position) {
+    if (level.getBlockEntity(position) instanceof HoneyCocoonBlockEntity blockEntity) {
+      return LootrAPI.getModdedMenu(blockEntity.getLevel(), blockEntity.getBlockEntityUuid(), blockEntity.getBlockPos(), player, blockEntity, (lootPlayer, inventory, table, seed) -> LootrCompat.unpackLootTable(blockEntity, lootPlayer, inventory, table, seed), blockEntity::getLootTable, blockEntity::getLootSeed);
+    }
+
+    return null;
+  }
+
+  public static void unpackLootTable(HoneyCocoonBlockEntity blockEntity, Player player, Container inventory, ResourceLocation table, long seed) {
+    if (table == null) {
+      LootrAPI.LOG.error("Unable to fill loot cocoon in " + blockEntity.getLevel().dimension() + " at " + blockEntity.getBlockPos() + " as the loot table was null.");
+      return;
+    }
+    LootTable loottable = blockEntity.getLevel().getServer().getLootData().getLootTable(table);
+    if (loottable == LootTable.EMPTY) {
+      LootrAPI.LOG.error("Unable to fill loot cocoon in " + blockEntity.getLevel().dimension() + " at " + blockEntity.getBlockPos() + " as the loot table '" + table + "' couldn't be resolved! Please search the loot table in `latest.log` to see if there are errors in loading.");
+      return;
+    }
+    LootParams.Builder builder = (new LootParams.Builder((ServerLevel) blockEntity.getLevel()).withParameter(LootContextParams.ORIGIN, Vec3.atCenterOf(blockEntity.getBlockPos())));
+    if (player != null) {
+      builder.withLuck(player.getLuck()).withParameter(LootContextParams.THIS_ENTITY, player);
+    }
+    loottable.fill(inventory, builder.create(LootContextParamSets.CHEST), LootrAPI.getLootSeed(seed));
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,6 +40,8 @@ blueprint_file_id=4019850
 potionofbees_file_id=3943639
 indium_file_id=4388133
 travelersbackpacks_file_id=4449240
+lootr_file_id=4607991
+lootr_fabric_file_id=4607996
 
 # Helper Dependencies that only exist at runtime
 commandstructures_forge=4.0.1+1.19.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx4G
+org.gradle.jvmargs=-Xmx6G
 minecraft_version=1.20.1
 archives_base_name=the_bumblezone
 mod_version=7.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,8 +40,8 @@ blueprint_file_id=4019850
 potionofbees_file_id=3943639
 indium_file_id=4388133
 travelersbackpacks_file_id=4449240
-lootr_file_id=4607991
-lootr_fabric_file_id=4607996
+lootr_file_id=4608503
+lootr_fabric_file_id=4608507
 
 # Helper Dependencies that only exist at runtime
 commandstructures_forge=4.0.1+1.19.4

--- a/quilt/build.gradle
+++ b/quilt/build.gradle
@@ -54,6 +54,9 @@ dependencies {
         force = true
     }
 
+    modCompileOnly("curse.maven:lootr_fabric-615106:${project.lootr_fabric_file_id}")
+    modRuntimeOnly("curse.maven:lootr_fabric-615106:${project.lootr_fabric_file_id}")
+
     modImplementation("maven.modrinth:midnightlib:${rootProject.midnightlib}")
 
     modCompileOnly("maven.modrinth:modmenu:${rootProject.mod_menu}")

--- a/quilt/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/quilt/LootrCompatImpl.java
+++ b/quilt/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/quilt/LootrCompatImpl.java
@@ -1,0 +1,39 @@
+package com.telepathicgrunt.the_bumblezone.modcompat.quilt;
+
+import com.telepathicgrunt.the_bumblezone.blocks.blockentities.HoneyCocoonBlockEntity;
+import com.telepathicgrunt.the_bumblezone.modcompat.LootrCompat;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.Container;
+import net.minecraft.world.MenuProvider;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.storage.loot.LootParams;
+import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.phys.Vec3;
+import net.zestyblaze.lootr.api.LootrAPI;
+
+public class LootrCompatImpl {
+  public static MenuProvider getCocoonMenu(ServerPlayer player, HoneyCocoonBlockEntity blockEntity) {
+    return LootrAPI.getModdedMenu(blockEntity.getLevel(), blockEntity.getBlockEntityUuid(), blockEntity.getBlockPos(), player, blockEntity, (lootPlayer, inventory, table, seed) -> LootrCompat.unpackLootTable(blockEntity, lootPlayer, inventory, table, seed), blockEntity::getLootTable, blockEntity::getLootSeed, LootrCompat::menuBuilder);
+  }
+
+  public static void unpackLootTable(HoneyCocoonBlockEntity blockEntity, Player player, Container inventory, ResourceLocation table, long seed) {
+    if (table == null) {
+      LootrAPI.LOG.error("Unable to fill loot cocoon in " + blockEntity.getLevel().dimension() + " at " + blockEntity.getBlockPos() + " as the loot table was null.");
+      return;
+    }
+    LootTable loottable = blockEntity.getLevel().getServer().getLootData().getLootTable(table);
+    if (loottable == LootTable.EMPTY) {
+      LootrAPI.LOG.error("Unable to fill loot cocoon in " + blockEntity.getLevel().dimension() + " at " + blockEntity.getBlockPos() + " as the loot table '" + table + "' couldn't be resolved! Please search the loot table in `latest.log` to see if there are errors in loading.");
+      return;
+    }
+    LootParams.Builder builder = (new LootParams.Builder((ServerLevel) blockEntity.getLevel()).withParameter(LootContextParams.ORIGIN, Vec3.atCenterOf(blockEntity.getBlockPos())));
+    if (player != null) {
+      builder.withLuck(player.getLuck()).withParameter(LootContextParams.THIS_ENTITY, player);
+    }
+    loottable.fill(inventory, builder.create(LootContextParamSets.CHEST), LootrAPI.getLootSeed(seed));
+  }
+}


### PR DESCRIPTION
So, the Forge version has been tested in single-player and appears to function properly. I was unable to test anything with Fabric or Quilt as that version of Lootr requires ClothConfig 2 11.0.99... which is the version that's compiled, but I couldn't work out how to actually enable it.

Things I'm not sure about how they will be handled:

- Hoppering items in and out (this may need to be prevented based on `IS_LOOT_CONTAINER`)
- Actually setting `IS_LOOT_CONTAINER` for things generated with loot.
- Separate texture for `IS_LOOT_CONTAINER` (blockstate etc)
- What will and should happen when a cocoon is broken
- How Forge capabilities will be handled.

At the very least, the bare minimum is implemented; additionally, it uses the `StrictChestMenu` to prevent shulker-box shenanigans.