### PR TITLE
Add custom FramedBlocks camo container to properly handle carvable wax on framed blocks

### DIFF
--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/AncientWax.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/AncientWax.java
@@ -1,26 +1,20 @@
 package com.telepathicgrunt.the_bumblezone.blocks;
 
 import com.mojang.serialization.MapCodec;
-import com.telepathicgrunt.the_bumblezone.modinit.BzCriterias;
 import com.telepathicgrunt.the_bumblezone.modinit.BzTags;
-import com.telepathicgrunt.the_bumblezone.utils.PlatformHooks;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.stats.Stats;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.ShearsItem;
-import net.minecraft.world.item.SwordItem;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.phys.BlockHitResult;
+import org.jetbrains.annotations.Nullable;
 
 
 public class AncientWax extends Block implements AncientWaxBase {
@@ -51,27 +45,24 @@ public class AncientWax extends Block implements AncientWaxBase {
 
     @Override
     public ItemInteractionResult useItemOn(ItemStack itemStack, BlockState blockState, Level level, BlockPos position, Player playerEntity, InteractionHand playerHand, BlockHitResult raytraceResult) {
-        if (PlatformHooks.isItemAbility(itemStack, ShearsItem.class, "shears_carve") ||
-            PlatformHooks.isItemAbility(itemStack, SwordItem.class, "sword_dig"))
-        {
-
-            ItemInteractionResult result = swapBlocks(level, blockState, position, BzTags.ANCIENT_WAX_FULL_BLOCKS);
-            if (result.consumesAction()) {
-                this.spawnDestroyParticles(level, playerEntity, position, blockState);
-
-                playerEntity.awardStat(Stats.ITEM_USED.get(itemStack.getItem()));
-                if (playerEntity instanceof ServerPlayer serverPlayer) {
-                    BzCriterias.CARVE_WAX_TRIGGER.get().trigger(serverPlayer, position);
-
-                    if (!serverPlayer.getAbilities().instabuild) {
-                        itemStack.hurtAndBreak(1, serverPlayer, playerHand == InteractionHand.MAIN_HAND ? EquipmentSlot.MAINHAND : EquipmentSlot.OFFHAND);
-                    }
-                }
-
-                return result;
-            }
+        BlockState swappedState = trySwap(itemStack, blockState, level, position, playerEntity, playerHand);
+        if (swappedState != null) {
+            level.setBlock(position, swappedState, 3);
+            return ItemInteractionResult.sidedSuccess(level.isClientSide());
         }
 
         return super.useItemOn(itemStack, blockState, level, position, playerEntity, playerHand, raytraceResult);
+    }
+
+    @Override
+    @Nullable
+    public BlockState trySwap(ItemStack itemStack, BlockState currentState, Level level, BlockPos blockPos, Player playerEntity, InteractionHand playerHand) {
+        BlockState swappedState = trySwap(itemStack, currentState, blockPos, playerEntity, playerHand, BzTags.ANCIENT_WAX_FULL_BLOCKS);
+        if (swappedState != null) {
+            this.spawnDestroyParticles(level, playerEntity, blockPos, currentState);
+            return swappedState;
+        }
+
+        return null;
     }
 }

--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/AncientWaxBase.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/AncientWaxBase.java
@@ -1,24 +1,31 @@
 package com.telepathicgrunt.the_bumblezone.blocks;
 
 import com.telepathicgrunt.the_bumblezone.items.essence.EssenceOfTheBees;
+import com.telepathicgrunt.the_bumblezone.modinit.BzCriterias;
 import com.telepathicgrunt.the_bumblezone.modinit.BzTags;
 import com.telepathicgrunt.the_bumblezone.utils.GeneralUtils;
+import com.telepathicgrunt.the_bumblezone.utils.PlatformHooks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderSet;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.stats.Stats;
 import net.minecraft.tags.TagKey;
-import net.minecraft.world.ItemInteractionResult;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ShearsItem;
+import net.minecraft.world.item.SwordItem;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Optional;
@@ -67,7 +74,17 @@ public interface AncientWaxBase {
         }
     }
 
-    default ItemInteractionResult swapBlocks(Level level, BlockState currentState, BlockPos blockPos, TagKey<Block> blockIterationTag) {
+    @Nullable
+    BlockState trySwap(ItemStack itemStack, BlockState currentState, Level level, BlockPos blockPos, Player playerEntity, InteractionHand playerHand);
+
+    @Nullable
+    default BlockState trySwap(ItemStack itemStack, BlockState currentState, BlockPos blockPos, Player playerEntity, InteractionHand playerHand, TagKey<Block> blockIterationTag) {
+        if (!PlatformHooks.isItemAbility(itemStack, ShearsItem.class, "shears_carve") &&
+            !PlatformHooks.isItemAbility(itemStack, SwordItem.class, "sword_dig"))
+        {
+            return null;
+        }
+
         Optional<HolderSet.Named<Block>> tagEntries = BuiltInRegistries.BLOCK.getTag(blockIterationTag);
         if (tagEntries.isPresent() && tagEntries.get().size() > 1) {
 
@@ -84,12 +101,20 @@ public interface AncientWaxBase {
                     }
                 }
 
-                level.setBlock(blockPos, newState, 3);
-                return ItemInteractionResult.sidedSuccess(level.isClientSide());
+                playerEntity.awardStat(Stats.ITEM_USED.get(itemStack.getItem()));
+                if (playerEntity instanceof ServerPlayer serverPlayer) {
+                    BzCriterias.CARVE_WAX_TRIGGER.get().trigger(serverPlayer, blockPos);
+
+                    if (!serverPlayer.getAbilities().instabuild) {
+                        itemStack.hurtAndBreak(1, serverPlayer, LivingEntity.getSlotForHand(playerHand));
+                    }
+                }
+
+                return newState;
             }
 
         }
 
-        return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
+        return null;
     }
 }

--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/AncientWaxSlab.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/AncientWaxSlab.java
@@ -1,20 +1,13 @@
 package com.telepathicgrunt.the_bumblezone.blocks;
 
 import com.mojang.serialization.MapCodec;
-import com.telepathicgrunt.the_bumblezone.modinit.BzCriterias;
 import com.telepathicgrunt.the_bumblezone.modinit.BzTags;
-import com.telepathicgrunt.the_bumblezone.utils.PlatformHooks;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.stats.Stats;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.ShearsItem;
-import net.minecraft.world.item.SwordItem;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SlabBlock;
@@ -22,6 +15,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.phys.BlockHitResult;
+import org.jetbrains.annotations.Nullable;
 
 
 public class AncientWaxSlab extends SlabBlock implements AncientWaxBase {
@@ -52,27 +46,24 @@ public class AncientWaxSlab extends SlabBlock implements AncientWaxBase {
 
     @Override
     public ItemInteractionResult useItemOn(ItemStack itemStack, BlockState blockState, Level level, BlockPos position, Player playerEntity, InteractionHand playerHand, BlockHitResult raytraceResult) {
-        if (PlatformHooks.isItemAbility(itemStack, ShearsItem.class, "shears_carve") ||
-            PlatformHooks.isItemAbility(itemStack, SwordItem.class, "sword_dig"))
-        {
-
-            ItemInteractionResult result = swapBlocks(level, blockState, position, BzTags.ANCIENT_WAX_SLABS);
-            if (result.consumesAction()) {
-                this.spawnDestroyParticles(level, playerEntity, position, blockState);
-
-                playerEntity.awardStat(Stats.ITEM_USED.get(itemStack.getItem()));
-                if (playerEntity instanceof ServerPlayer serverPlayer) {
-                    BzCriterias.CARVE_WAX_TRIGGER.get().trigger(serverPlayer, position);
-
-                    if (!serverPlayer.getAbilities().instabuild) {
-                        itemStack.hurtAndBreak(1, serverPlayer, playerHand == InteractionHand.MAIN_HAND ? EquipmentSlot.MAINHAND : EquipmentSlot.OFFHAND);
-                    }
-                }
-
-                return result;
-            }
+        BlockState swappedState = trySwap(itemStack, blockState, level, position, playerEntity, playerHand);
+        if (swappedState != null) {
+            level.setBlock(position, swappedState, 3);
+            return ItemInteractionResult.sidedSuccess(level.isClientSide());
         }
 
         return super.useItemOn(itemStack, blockState, level, position, playerEntity, playerHand, raytraceResult);
+    }
+
+    @Override
+    @Nullable
+    public BlockState trySwap(ItemStack itemStack, BlockState currentState, Level level, BlockPos blockPos, Player playerEntity, InteractionHand playerHand) {
+        BlockState swappedState = trySwap(itemStack, currentState, blockPos, playerEntity, playerHand, BzTags.ANCIENT_WAX_SLABS);
+        if (swappedState != null) {
+            this.spawnDestroyParticles(level, playerEntity, blockPos, currentState);
+            return swappedState;
+        }
+
+        return null;
     }
 }

--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/CarvableWax.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/CarvableWax.java
@@ -12,7 +12,7 @@ import net.minecraft.stats.Stats;
 import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.ItemInteractionResult;
-import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -29,6 +29,7 @@ import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.phys.BlockHitResult;
+import org.jetbrains.annotations.Nullable;
 
 
 public class CarvableWax extends ProperFacingBlock {
@@ -110,6 +111,10 @@ public class CarvableWax extends ProperFacingBlock {
      */
     @Override
     public ItemStack getCloneItemStack(LevelReader level, BlockPos pos, BlockState state) {
+        return toItemStack(state);
+    }
+
+    public ItemStack toItemStack(BlockState state) {
         if (state.hasProperty(CARVING)) {
             Carving pattern = state.getValue(CARVING);
 
@@ -150,11 +155,21 @@ public class CarvableWax extends ProperFacingBlock {
 
     @Override
     public ItemInteractionResult useItemOn(ItemStack itemStack, BlockState blockState, Level level, BlockPos position, Player playerEntity, InteractionHand playerHand, BlockHitResult raytraceResult) {
+        BlockState carvedState = tryCarve(itemStack, blockState, level, position, playerEntity, playerHand);
+        if (carvedState != null) {
+            level.setBlock(position, carvedState, 3);
+            return ItemInteractionResult.sidedSuccess(level.isClientSide());
+        }
+
+        return super.useItemOn(itemStack, blockState, level, position, playerEntity, playerHand, raytraceResult);
+    }
+
+    @Nullable
+    public BlockState tryCarve(ItemStack itemStack, BlockState blockState, Level level, BlockPos position, Player playerEntity, InteractionHand playerHand) {
         if (blockState.hasProperty(CARVING) &&
             (PlatformHooks.isItemAbility(itemStack, ShearsItem.class, "shears_carve") ||
             PlatformHooks.isItemAbility(itemStack, SwordItem.class, "sword_dig")))
         {
-            level.setBlock(position, BzBlocks.CARVABLE_WAX.get().defaultBlockState().setValue(CARVING, blockState.getValue(CARVING).next()), 3);
             this.spawnDestroyParticles(level, playerEntity, position,blockState);
 
             playerEntity.awardStat(Stats.ITEM_USED.get(itemStack.getItem()));
@@ -162,14 +177,14 @@ public class CarvableWax extends ProperFacingBlock {
                 BzCriterias.CARVE_WAX_TRIGGER.get().trigger(serverPlayer, position);
 
                 if (!serverPlayer.getAbilities().instabuild) {
-                    itemStack.hurtAndBreak(1, serverPlayer, playerHand == InteractionHand.MAIN_HAND ? EquipmentSlot.MAINHAND : EquipmentSlot.OFFHAND);
+                    itemStack.hurtAndBreak(1, serverPlayer, LivingEntity.getSlotForHand(playerHand));
                 }
             }
 
-            return ItemInteractionResult.SUCCESS;
+            return BzBlocks.CARVABLE_WAX.get().defaultBlockState().setValue(CARVING, blockState.getValue(CARVING).next());
         }
 
-        return super.useItemOn(itemStack, blockState, level, position, playerEntity, playerHand, raytraceResult);
+        return null;
     }
 
     /**

--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/LuminescentWaxBase.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/blocks/LuminescentWaxBase.java
@@ -3,16 +3,21 @@ package com.telepathicgrunt.the_bumblezone.blocks;
 import com.telepathicgrunt.the_bumblezone.items.essence.EssenceOfTheBees;
 import com.telepathicgrunt.the_bumblezone.modinit.BzEffects;
 import com.telepathicgrunt.the_bumblezone.modinit.BzTags;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
 
 public interface LuminescentWaxBase {
 
@@ -89,4 +94,7 @@ public interface LuminescentWaxBase {
             }
         }
     }
+
+    @Nullable
+    BlockState tryRotate(ItemStack itemStack, BlockState blockState, Level level, BlockPos position, Player playerEntity, InteractionHand playerHand);
 }

--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/items/BzBlockItem.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/items/BzBlockItem.java
@@ -6,6 +6,7 @@ import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
 
 public class BzBlockItem extends BlockItem {
     private final boolean fitInContainers;
@@ -47,5 +48,10 @@ public class BzBlockItem extends BlockItem {
             placingState = CarvableWax.getFacingStateForPlacement(placingState, context);
         }
         return placingState != null && this.canPlace(context, placingState) ? placingState : null;
+    }
+
+    @Nullable
+    public BlockState getBlockState() {
+        return blockState;
     }
 }

--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/ModChecker.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/ModChecker.java
@@ -56,6 +56,7 @@ public class ModChecker {
 	public static boolean tropicraftPresent = false;
 	public static boolean jeedPresent = false;
 	public static boolean tokenEnchanterPresent = false;
+	public static boolean framedBlocksPresent = false;
 
 	/*
 	 * -- DO NOT TURN THE LAMBDAS INTO METHOD REFS. Method refs are not classloading safe. --

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ pneumaticcraft_file_id=5321150
 ars_elemental_file_id=5255908
 # Temporary until we figure out why I cannot remap the mod from their maven.
 mekanism_file_id=5496791
-framedblocks_file_id=5588479
+framedblocks_file_id=5597081
 
 # Helper Dependencies that only exist at runtime
 commandstructures_neoforge=4.4.0+1.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,6 +46,7 @@ pneumaticcraft_file_id=5321150
 ars_elemental_file_id=5255908
 # Temporary until we figure out why I cannot remap the mod from their maven.
 mekanism_file_id=5496791
+framedblocks_file_id=5588479
 
 # Helper Dependencies that only exist at runtime
 commandstructures_neoforge=4.4.0+1.21

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -90,6 +90,7 @@ dependencies {
     // modRuntimeOnly("com.telepathicgrunt:CommandStructures-Neoforge:${project.commandstructures_neoforge}")
     // modRuntimeOnly("com.telepathicgrunt:StructureVoidToggle-Neoforge:${project.structurevoidtoggle_neoforge}")
 
+    modCompileOnly("curse.maven:framedblocks-441647:${project.framedblocks_file_id}")
 }
 
 processResources {

--- a/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/mixin/neoforge/block/UseOnContextAccessor.java
+++ b/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/mixin/neoforge/block/UseOnContextAccessor.java
@@ -1,0 +1,13 @@
+package com.telepathicgrunt.the_bumblezone.mixin.neoforge.block;
+
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.phys.BlockHitResult;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(UseOnContext.class)
+public interface UseOnContextAccessor {
+
+    @Accessor("hitResult")
+    BlockHitResult bz$getHitResult();
+}

--- a/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/NeoForgeModChecker.java
+++ b/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/NeoForgeModChecker.java
@@ -27,7 +27,7 @@ public class NeoForgeModChecker {
         String modid = "";
         try {
             modid = "framedblocks";
-            if (ModChecker.isNotOutdated(modid, "10.1.2", false)) {
+            if (ModChecker.isNotOutdated(modid, "10.1.3", false)) {
                 loadupModCompat(modid, () -> new FramedBlocksCompat(modEventBus));
             }
         }

--- a/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/NeoForgeModChecker.java
+++ b/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/NeoForgeModChecker.java
@@ -2,6 +2,8 @@ package com.telepathicgrunt.the_bumblezone.modcompat.neoforge;
 
 import com.telepathicgrunt.the_bumblezone.modcompat.BeekeeperCompat;
 import com.telepathicgrunt.the_bumblezone.modcompat.ModChecker;
+import com.telepathicgrunt.the_bumblezone.modcompat.neoforge.framedblocks.FramedBlocksCompat;
+import net.neoforged.bus.api.IEventBus;
 
 import static com.telepathicgrunt.the_bumblezone.modcompat.ModChecker.loadupModCompat;
 import static com.telepathicgrunt.the_bumblezone.modcompat.ModChecker.printErrorToLogs;
@@ -20,6 +22,21 @@ public class NeoForgeModChecker {
      * <p>
      * {@link ModChecker}
      */
+
+    public static void setupEarlyModCompat(IEventBus modEventBus) {
+        String modid = "";
+        try {
+            modid = "framedblocks";
+            if (ModChecker.isNotOutdated(modid, "10.1.2", false)) {
+                loadupModCompat(modid, () -> new FramedBlocksCompat(modEventBus));
+            }
+        }
+        catch (Throwable e) {
+            printErrorToLogs("classloading " + modid + " and so, mod compat done afterwards broke");
+            e.printStackTrace();
+        }
+    }
+
     public static void setupModCompat() {
         String modid = "";
         try {

--- a/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/framedblocks/CarvableWaxBlockCamoContainer.java
+++ b/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/framedblocks/CarvableWaxBlockCamoContainer.java
@@ -1,0 +1,46 @@
+package com.telepathicgrunt.the_bumblezone.modcompat.neoforge.framedblocks;
+
+import com.telepathicgrunt.the_bumblezone.blocks.CarvableWax;
+import net.minecraft.world.level.block.state.BlockState;
+import xfacthd.framedblocks.api.camo.block.AbstractBlockCamoContainer;
+import xfacthd.framedblocks.api.camo.block.AbstractBlockCamoContainerFactory;
+
+import java.util.Set;
+
+final class CarvableWaxBlockCamoContainer extends AbstractBlockCamoContainer<CarvableWaxBlockCamoContainer> {
+
+    private static final Set<CarvableWax.Carving> ROTATABLE = Set.of(
+            CarvableWax.Carving.WAVY,
+            CarvableWax.Carving.CHISELED,
+            CarvableWax.Carving.BRICKS,
+            CarvableWax.Carving.CHAINS,
+            CarvableWax.Carving.MUSIC
+    );
+
+    CarvableWaxBlockCamoContainer(BlockState state) {
+        super(state);
+    }
+
+    @Override
+    public boolean canRotateCamo() {
+        CarvableWax.Carving carving = getState().getValue(CarvableWax.CARVING);
+        return ROTATABLE.contains(carving) && super.canRotateCamo();
+    }
+
+    @Override
+    public int hashCode() {
+        return content.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != CarvableWaxBlockCamoContainer.class) return false;
+        return content.equals(((CarvableWaxBlockCamoContainer) obj).content);
+    }
+
+    @Override
+    public AbstractBlockCamoContainerFactory<CarvableWaxBlockCamoContainer> getFactory() {
+        return FramedBlocksCompat.WAX_BLOCK_CAMO_FACTORY.value();
+    }
+}

--- a/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/framedblocks/CarvableWaxBlockCamoContainer.java
+++ b/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/framedblocks/CarvableWaxBlockCamoContainer.java
@@ -7,8 +7,14 @@ import xfacthd.framedblocks.api.camo.block.AbstractBlockCamoContainerFactory;
 
 import java.util.Set;
 
+/**
+ * Container for camos made of {@link CarvableWax}
+ */
 final class CarvableWaxBlockCamoContainer extends AbstractBlockCamoContainer<CarvableWaxBlockCamoContainer> {
 
+    /**
+     * Set of carvable wax patterns which change visually when rotated
+     */
     private static final Set<CarvableWax.Carving> ROTATABLE = Set.of(
             CarvableWax.Carving.WAVY,
             CarvableWax.Carving.CHISELED,
@@ -21,6 +27,9 @@ final class CarvableWaxBlockCamoContainer extends AbstractBlockCamoContainer<Car
         super(state);
     }
 
+    /**
+     * {@return whether the camo state held by this camo container can be rotated with the framed screwdriver}
+     */
     @Override
     public boolean canRotateCamo() {
         CarvableWax.Carving carving = getState().getValue(CarvableWax.CARVING);
@@ -39,6 +48,15 @@ final class CarvableWaxBlockCamoContainer extends AbstractBlockCamoContainer<Car
         return content.equals(((CarvableWaxBlockCamoContainer) obj).content);
     }
 
+    @Override
+    public String toString()
+    {
+        return "CarvableWaxBlockCamoContainer{" + content + "}";
+    }
+
+    /**
+     * {@return the camo container factory used to create and manage camo containers of this type}
+     */
     @Override
     public AbstractBlockCamoContainerFactory<CarvableWaxBlockCamoContainer> getFactory() {
         return FramedBlocksCompat.WAX_BLOCK_CAMO_FACTORY.value();

--- a/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/framedblocks/CarvableWaxBlockCamoContainerFactory.java
+++ b/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/framedblocks/CarvableWaxBlockCamoContainerFactory.java
@@ -21,6 +21,11 @@ import xfacthd.framedblocks.api.camo.TriggerRegistrar;
 import xfacthd.framedblocks.api.camo.block.AbstractBlockCamoContainerFactory;
 import xfacthd.framedblocks.api.util.Utils;
 
+/**
+ * Factory for creating {@link CarvableWaxBlockCamoContainer}s when a {@link CarvableWax} block is applied as a camo
+ * to a framed block. This is necessary as carvable wax places blocks with a blockstate property that depends on the
+ * item being used, which FramedBlocks cannot deal with by default and instead defaults to the default state of the block
+ */
 final class CarvableWaxBlockCamoContainerFactory extends AbstractBlockCamoContainerFactory<CarvableWaxBlockCamoContainer> {
 
     private static final MapCodec<CarvableWaxBlockCamoContainer> CODEC = BlockState.CODEC
@@ -28,6 +33,15 @@ final class CarvableWaxBlockCamoContainerFactory extends AbstractBlockCamoContai
     private static final StreamCodec<ByteBuf, CarvableWaxBlockCamoContainer> STREAM_CODEC = ByteBufCodecs.idMapper(Block.BLOCK_STATE_REGISTRY)
             .map(CarvableWaxBlockCamoContainer::new, CarvableWaxBlockCamoContainer::getState);
 
+    /**
+     * Compute the {@linkplain BlockState camo state} associated with the {@link ItemStack} used for applying the camo
+     *
+     * @param level The level of the framed block the camo is being applied to
+     * @param pos The position of the framed block the camo is being applied to
+     * @param player The player applying the camo
+     * @param stack The stack with which the camo is being applied
+     * @return the {@linkplain BlockState camo state} associated with the {@link ItemStack} used for applying the camo
+     */
     @Override
     @Nullable
     protected BlockState getStateFromItemStack(Level level, BlockPos pos, Player player, ItemStack stack) {
@@ -37,26 +51,59 @@ final class CarvableWaxBlockCamoContainerFactory extends AbstractBlockCamoContai
         return null;
     }
 
+    /**
+     * Create the camo container resulting from the computed {@linkplain BlockState camo state} and additional context when applying the camo
+     *
+     * @param level The level of the framed block the camo is being applied to
+     * @param pos The position of the framed block the camo is being applied to
+     * @param player The player applying the camo
+     * @param stack The stack with which the camo is being applied
+     * @return the camo container resulting from the computed {@linkplain BlockState camo state} and additional context
+     */
     @Override
     protected CarvableWaxBlockCamoContainer createContainer(BlockState camoState, Level level, BlockPos pos, Player player, ItemStack stack) {
         return new CarvableWaxBlockCamoContainer(camoState);
     }
 
+    /**
+     * Create a copy of the given camo container with the camo state replaced by the given new {@linkplain BlockState camo state}
+     *
+     * @param original The original camo container
+     * @param newCamoState The new camo state to store in the copied container
+     * @return the copied camo container with the new camo state
+     */
     @Override
     protected CarvableWaxBlockCamoContainer copyContainerWithState(CarvableWaxBlockCamoContainer original, BlockState newCamoState) {
         return new CarvableWaxBlockCamoContainer(newCamoState);
     }
 
+    /**
+     * Check whether the given {@linkplain BlockState camo state} is a valid camo in the given context when applied
+     * by a player or loaded from disk
+     *
+     * @param camoState The camo state to check
+     * @param level The level of the framed block the camo is being applied to or loaded on
+     * @param pos The position of the framed block the camo is being applied to or loaded on
+     * @param player The player applying the camo, if available
+     * @return whether the given camo is valid in the given context
+     */
     @Override
     protected boolean isValidBlock(BlockState camoState, BlockGetter level, BlockPos pos, @Nullable Player player) {
         return camoState.getBlock() instanceof CarvableWax;
     }
 
+    /**
+     * {@return whether a camo container produced by this factory can be trivially converted to an {@link ItemStack}
+     * without any additional context or resource consumption}
+     */
     @Override
     public boolean canTriviallyConvertToItemStack() {
         return true;
     }
 
+    /**
+     * {@return the {@link ItemStack} to drop when a framed block with the given camo container applied is broken}
+     */
     @Override
     public ItemStack dropCamo(CarvableWaxBlockCamoContainer container) {
         if (container.getState().getBlock() instanceof CarvableWax carvableWax) {
@@ -65,32 +112,61 @@ final class CarvableWaxBlockCamoContainerFactory extends AbstractBlockCamoContai
         return new ItemStack(container.getState().getBlock());
     }
 
+    /**
+     * Create the {@link ItemStack} to return to the player when removing the given camo container with a valid removal tool
+     *
+     * @param level The level of the framed block the camo is being removed from
+     * @param pos The position of the framed block the camo is being removed from
+     * @param player The player removing the camo
+     * @param stack The stack with which the camo is being removed
+     * @param container The camo container being removed
+     * @return The {@link ItemStack} to return to the player
+     */
     @Override
     protected ItemStack createItemStack(Level level, BlockPos pos, Player player, ItemStack stack, CarvableWaxBlockCamoContainer container) {
         return dropCamo(container);
     }
 
+    /**
+     * Write the relevant data of the given camo container to the given NBT tag for syncing to the client
+     * @param tag The NBT tag to write the relevant data to
+     * @param container The camo container to be synced
+     */
     @Override
     protected void writeToNetwork(CompoundTag tag, CarvableWaxBlockCamoContainer container) {
         tag.putInt("state", Block.getId(container.getState()));
     }
 
+    /**
+     * Reconstruct a camo container from the given network-synced NBT tag
+     * @param tag The NBT tag received over the network
+     * @return The reconstructed camo container
+     */
     @Override
     protected CarvableWaxBlockCamoContainer readFromNetwork(CompoundTag tag) {
         BlockState state = Block.stateById(tag.getInt("state"));
         return new CarvableWaxBlockCamoContainer(state);
     }
 
+    /**
+     * {@return a {@link MapCodec} for reading and writing the camo container from and to disk}
+     */
     @Override
     public MapCodec<CarvableWaxBlockCamoContainer> codec() {
         return CODEC;
     }
 
+    /**
+     * {@return a {@link StreamCodec} for reading and writing the camo container from and to network packets}
+     */
     @Override
     public StreamCodec<? super RegistryFriendlyByteBuf, CarvableWaxBlockCamoContainer> streamCodec() {
         return STREAM_CODEC;
     }
 
+    /**
+     * Register valid items for applying and removing camo containers made by this factory to and from a framed block
+     */
     @Override
     public void registerTriggerItems(TriggerRegistrar registrar) {
         registrar.registerApplicationItem(BzItems.CARVABLE_WAX.get());

--- a/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/framedblocks/CarvableWaxBlockCamoContainerFactory.java
+++ b/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/framedblocks/CarvableWaxBlockCamoContainerFactory.java
@@ -1,0 +1,108 @@
+package com.telepathicgrunt.the_bumblezone.modcompat.neoforge.framedblocks;
+
+import com.mojang.serialization.MapCodec;
+import com.telepathicgrunt.the_bumblezone.blocks.CarvableWax;
+import com.telepathicgrunt.the_bumblezone.items.BzBlockItem;
+import com.telepathicgrunt.the_bumblezone.modinit.BzItems;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+import xfacthd.framedblocks.api.camo.TriggerRegistrar;
+import xfacthd.framedblocks.api.camo.block.AbstractBlockCamoContainerFactory;
+import xfacthd.framedblocks.api.util.Utils;
+
+final class CarvableWaxBlockCamoContainerFactory extends AbstractBlockCamoContainerFactory<CarvableWaxBlockCamoContainer> {
+
+    private static final MapCodec<CarvableWaxBlockCamoContainer> CODEC = BlockState.CODEC
+            .xmap(CarvableWaxBlockCamoContainer::new, CarvableWaxBlockCamoContainer::getState).fieldOf("state");
+    private static final StreamCodec<ByteBuf, CarvableWaxBlockCamoContainer> STREAM_CODEC = ByteBufCodecs.idMapper(Block.BLOCK_STATE_REGISTRY)
+            .map(CarvableWaxBlockCamoContainer::new, CarvableWaxBlockCamoContainer::getState);
+
+    @Override
+    @Nullable
+    protected BlockState getStateFromItemStack(Level level, BlockPos pos, Player player, ItemStack stack) {
+        if (stack.getItem() instanceof BzBlockItem item && item.getBlock() instanceof CarvableWax) {
+            return item.getBlockState();
+        }
+        return null;
+    }
+
+    @Override
+    protected CarvableWaxBlockCamoContainer createContainer(BlockState camoState, Level level, BlockPos pos, Player player, ItemStack stack) {
+        return new CarvableWaxBlockCamoContainer(camoState);
+    }
+
+    @Override
+    protected CarvableWaxBlockCamoContainer copyContainerWithState(CarvableWaxBlockCamoContainer original, BlockState newCamoState) {
+        return new CarvableWaxBlockCamoContainer(newCamoState);
+    }
+
+    @Override
+    protected boolean isValidBlock(BlockState camoState, BlockGetter level, BlockPos pos, @Nullable Player player) {
+        return camoState.getBlock() instanceof CarvableWax;
+    }
+
+    @Override
+    public boolean canTriviallyConvertToItemStack() {
+        return true;
+    }
+
+    @Override
+    public ItemStack dropCamo(CarvableWaxBlockCamoContainer container) {
+        if (container.getState().getBlock() instanceof CarvableWax carvableWax) {
+            return carvableWax.toItemStack(container.getState());
+        }
+        return new ItemStack(container.getState().getBlock());
+    }
+
+    @Override
+    protected ItemStack createItemStack(Level level, BlockPos pos, Player player, ItemStack stack, CarvableWaxBlockCamoContainer container) {
+        return dropCamo(container);
+    }
+
+    @Override
+    protected void writeToNetwork(CompoundTag tag, CarvableWaxBlockCamoContainer container) {
+        tag.putInt("state", Block.getId(container.getState()));
+    }
+
+    @Override
+    protected CarvableWaxBlockCamoContainer readFromNetwork(CompoundTag tag) {
+        BlockState state = Block.stateById(tag.getInt("state"));
+        return new CarvableWaxBlockCamoContainer(state);
+    }
+
+    @Override
+    public MapCodec<CarvableWaxBlockCamoContainer> codec() {
+        return CODEC;
+    }
+
+    @Override
+    public StreamCodec<? super RegistryFriendlyByteBuf, CarvableWaxBlockCamoContainer> streamCodec() {
+        return STREAM_CODEC;
+    }
+
+    @Override
+    public void registerTriggerItems(TriggerRegistrar registrar) {
+        registrar.registerApplicationItem(BzItems.CARVABLE_WAX.get());
+        registrar.registerApplicationItem(BzItems.CARVABLE_WAX_WAVY.get());
+        registrar.registerApplicationItem(BzItems.CARVABLE_WAX_FLOWER.get());
+        registrar.registerApplicationItem(BzItems.CARVABLE_WAX_CHISELED.get());
+        registrar.registerApplicationItem(BzItems.CARVABLE_WAX_DIAMOND.get());
+        registrar.registerApplicationItem(BzItems.CARVABLE_WAX_BRICKS.get());
+        registrar.registerApplicationItem(BzItems.CARVABLE_WAX_CHAINS.get());
+        registrar.registerApplicationItem(BzItems.CARVABLE_WAX_MUSIC.get());
+        registrar.registerApplicationItem(BzItems.CARVABLE_WAX_GRATE.get());
+
+        registrar.registerRemovalItem(Utils.FRAMED_HAMMER.value());
+    }
+}

--- a/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/framedblocks/FramedBlocksCompat.java
+++ b/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/framedblocks/FramedBlocksCompat.java
@@ -38,6 +38,12 @@ public final class FramedBlocksCompat implements ModCompat {
         ModChecker.framedBlocksPresent = true;
     }
 
+    /**
+     * Event handler for managing custom interactions with carvable wax, ancient wax and luminescent wax when applied
+     * as a camo to a framed block. To do so, the camo is retrieved from the framed block via the player's interaction
+     * point on the block, the stored state is modified as necessary and then a new camo container with the modified
+     * state is written back to the framed block
+     */
     private static void onItemUsedOnBlock(UseItemOnBlockEvent event) {
         Level level = event.getLevel();
         Player player = event.getPlayer();
@@ -52,7 +58,7 @@ public final class FramedBlocksCompat implements ModCompat {
             BlockState carvedState = wax.tryCarve(event.getItemStack(), waxCamo.getState(), level, pos, player, event.getHand());
             if (carvedState != null) {
                 if (!level.isClientSide()) {
-                    be.setCamo(new CarvableWaxBlockCamoContainer(carvedState), hit, player);
+                    be.setCamo(waxCamo.copyWithState(carvedState), hit, player);
                 }
                 event.cancelWithResult(ItemInteractionResult.sidedSuccess(level.isClientSide()));
             }

--- a/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/framedblocks/FramedBlocksCompat.java
+++ b/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/framedblocks/FramedBlocksCompat.java
@@ -1,0 +1,60 @@
+package com.telepathicgrunt.the_bumblezone.modcompat.neoforge.framedblocks;
+
+import com.telepathicgrunt.the_bumblezone.Bumblezone;
+import com.telepathicgrunt.the_bumblezone.blocks.CarvableWax;
+import com.telepathicgrunt.the_bumblezone.mixin.neoforge.block.UseOnContextAccessor;
+import com.telepathicgrunt.the_bumblezone.modcompat.ModChecker;
+import com.telepathicgrunt.the_bumblezone.modcompat.ModCompat;
+import net.minecraft.world.ItemInteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.entity.player.UseItemOnBlockEvent;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import xfacthd.framedblocks.api.block.blockentity.FramedBlockEntity;
+import xfacthd.framedblocks.api.camo.CamoContainer;
+import xfacthd.framedblocks.api.camo.CamoContainerFactory;
+import xfacthd.framedblocks.api.util.FramedConstants;
+
+public final class FramedBlocksCompat implements ModCompat {
+
+    private static final DeferredRegister<CamoContainerFactory<?>> CAMO_FACTORIES = DeferredRegister.create(
+            FramedConstants.CAMO_CONTAINER_FACTORY_REGISTRY_NAME,
+            Bumblezone.MODID
+    );
+    static final DeferredHolder<CamoContainerFactory<?>, CarvableWaxBlockCamoContainerFactory> WAX_BLOCK_CAMO_FACTORY =
+            CAMO_FACTORIES.register("carvable_wax", CarvableWaxBlockCamoContainerFactory::new);
+
+    public FramedBlocksCompat(IEventBus modEventBus) {
+        CAMO_FACTORIES.register(modEventBus);
+        NeoForge.EVENT_BUS.addListener(FramedBlocksCompat::onItemUsedOnBlock);
+
+        ModChecker.framedBlocksPresent = true;
+    }
+
+    private static void onItemUsedOnBlock(UseItemOnBlockEvent event) {
+        Level level = event.getLevel();
+        Player player = event.getPlayer();
+        if (player == null || !(level.getBlockEntity(event.getPos()) instanceof FramedBlockEntity be)) {
+            return;
+        }
+
+        BlockHitResult hit = ((UseOnContextAccessor) event.getUseOnContext()).bz$getHitResult();
+        CamoContainer<?, ?> camo = be.getCamo(hit, player);
+        if (!(camo instanceof CarvableWaxBlockCamoContainer waxCamo) || !(waxCamo.getState().getBlock() instanceof CarvableWax wax)) {
+            return;
+        }
+
+        BlockState carvedState = wax.tryCarve(event.getItemStack(), waxCamo.getState(), level, event.getPos(), player, event.getHand());
+        if (carvedState != null) {
+            if (!level.isClientSide()) {
+                be.setCamo(new CarvableWaxBlockCamoContainer(carvedState), hit, player);
+            }
+            event.cancelWithResult(ItemInteractionResult.sidedSuccess(level.isClientSide()));
+        }
+    }
+}

--- a/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/framedblocks/FramedBlocksCompat.java
+++ b/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/neoforge/framedblocks/FramedBlocksCompat.java
@@ -21,7 +21,6 @@ import xfacthd.framedblocks.api.camo.CamoContainer;
 import xfacthd.framedblocks.api.camo.CamoContainerFactory;
 import xfacthd.framedblocks.api.camo.block.AbstractBlockCamoContainer;
 import xfacthd.framedblocks.api.util.FramedConstants;
-import xfacthd.framedblocks.common.data.camo.block.BlockCamoContainer;
 
 public final class FramedBlocksCompat implements ModCompat {
 
@@ -63,8 +62,7 @@ public final class FramedBlocksCompat implements ModCompat {
                 BlockState rotatedState = lumiWax.tryRotate(event.getItemStack(), blockCamo.getState(), level, pos, player, event.getHand());
                 if (rotatedState != null) {
                     if (!level.isClientSide()) {
-                        //be.setCamo(blockCamo.copyWithState(blockCamo, rotatedState), hit, player);
-                        be.setCamo(new BlockCamoContainer(rotatedState), hit, player);
+                        be.setCamo(blockCamo.copyWithState(rotatedState), hit, player);
                     }
                     event.cancelWithResult(ItemInteractionResult.sidedSuccess(level.isClientSide()));
                 }
@@ -73,8 +71,7 @@ public final class FramedBlocksCompat implements ModCompat {
                 BlockState swappedState = ancientWax.trySwap(event.getItemStack(), blockCamo.getState(), level, pos, player, event.getHand());
                 if (swappedState != null) {
                     if (!level.isClientSide()) {
-                        //be.setCamo(blockCamo.copyWithState(blockCamo, swappedState), hit, player);
-                        be.setCamo(new BlockCamoContainer(swappedState), hit, player);
+                        be.setCamo(blockCamo.copyWithState(swappedState), hit, player);
                     }
                     event.cancelWithResult(ItemInteractionResult.sidedSuccess(level.isClientSide()));
                 }

--- a/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/neoforge/BumblezoneNeoForge.java
+++ b/neoforge/src/main/java/com/telepathicgrunt/the_bumblezone/neoforge/BumblezoneNeoForge.java
@@ -2,6 +2,7 @@ package com.telepathicgrunt.the_bumblezone.neoforge;
 
 import com.telepathicgrunt.the_bumblezone.Bumblezone;
 import com.telepathicgrunt.the_bumblezone.configs.neoforge.BzConfigHandler;
+import com.telepathicgrunt.the_bumblezone.modcompat.neoforge.NeoForgeModChecker;
 import com.telepathicgrunt.the_bumblezone.modinit.neoforge.BzAttachmentTypes;
 import com.telepathicgrunt.the_bumblezone.modinit.neoforge.BzBiomeModifiers;
 import com.telepathicgrunt.the_bumblezone.modinit.neoforge.BzGlobalLootModifier;
@@ -30,5 +31,7 @@ public class BumblezoneNeoForge {
         NeoForgeEventManager.init(modEventBus, eventBus);
 
         NeoForgeMod.enableProperFilenameValidation();
+
+        NeoForgeModChecker.setupEarlyModCompat(modEventBus);
     }
 }

--- a/neoforge/src/main/resources/the_bumblezone-neoforge.mixins.json
+++ b/neoforge/src/main/resources/the_bumblezone-neoforge.mixins.json
@@ -7,6 +7,7 @@
     "block.FireBlockInvoker",
     "block.FireBlockMixin",
     "block.SuperCandleMixin",
+    "block.UseOnContextAccessor",
     "effect.WrathOfTheHiveEffectMixin",
     "entity.EntityMixin",
     "item.BzArrowItemMixin",


### PR DESCRIPTION
This PR implements a dedicated `CamoContainer` and associated `CamoContainerFactory` to improve the handling of the Carvable Wax block when applied as a camo to a framed block. This allows the individual items to properly apply the correct carving pattern and also allows players to change the pattern while the Carvable Wax is applied as a camo.