### PR TITLE
make queen bee turning a bit more stable

### DIFF
--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/entities/goals/BeeQueenAlwaysLookAtPlayerGoal.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/entities/goals/BeeQueenAlwaysLookAtPlayerGoal.java
@@ -7,6 +7,7 @@ import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.targeting.TargetingConditions;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.Vec3;
 
 import java.util.EnumSet;
 
@@ -17,6 +18,8 @@ public class BeeQueenAlwaysLookAtPlayerGoal extends Goal {
     private final boolean onlyHorizontal;
     protected final Class<? extends LivingEntity> lookAtType;
     protected final TargetingConditions lookAtContext;
+    private int lookCooldown;
+    private Vec3 lookPos;
 
     public BeeQueenAlwaysLookAtPlayerGoal(Mob mob, Class<? extends LivingEntity> lookAtType, float lookDistance) {
         this(mob, lookAtType, lookDistance, false);
@@ -27,6 +30,8 @@ public class BeeQueenAlwaysLookAtPlayerGoal extends Goal {
         this.lookAtType = lookAtType;
         this.lookDistance = lookDistance;
         this.onlyHorizontal = onlyHorizontal;
+        this.lookCooldown = 0;
+        this.lookPos = new Vec3(0, 0, 0);
         this.setFlags(EnumSet.of(Flag.LOOK));
         if (lookAtType == Player.class) {
             this.lookAtContext = TargetingConditions.forNonCombat().range(lookDistance).selector((livingEntity) -> EntitySelector.notRiding(mob).test(livingEntity));
@@ -66,9 +71,25 @@ public class BeeQueenAlwaysLookAtPlayerGoal extends Goal {
     }
 
     public void tick() {
-        if (this.lookAt != null && this.lookAt.isAlive()) {
-            double y = this.onlyHorizontal ? this.mob.getEyeY() : this.lookAt.getEyeY();
-            this.mob.getLookControl().setLookAt(this.lookAt.getX(), y, this.lookAt.getZ(), 0.05f, 0.05f);
+        if (this.lookCooldown >= 0 && this.lookAt != null && this.lookAt.isAlive()) {
+            if (this.lookCooldown == 19) {
+                this.updateLookCoordinates();
+            }
+            this.mob.getLookControl().setLookAt(this.lookPos.x, this.lookPos.y, this.lookPos.z, 360, 40);
+        }
+        if (this.lookCooldown <= 0) {
+            this.lookCooldown = 20;
+        }
+        this.lookCooldown--;
+    }
+
+    private void updateLookCoordinates() {
+        double newX = this.lookAt.getX();
+        double newY = this.onlyHorizontal ? this.mob.getEyeY() : this.lookAt.getEyeY();
+        double newZ = this.lookAt.getZ();
+        Vec3 newPos = new Vec3(newX, newY, newZ);
+        if (this.lookPos.distanceToSqr(newPos) > 2) {
+            this.lookPos = newPos;
         }
     }
 }

--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/entities/mobs/BeeQueenEntity.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/entities/mobs/BeeQueenEntity.java
@@ -964,16 +964,6 @@ public class BeeQueenEntity extends Animal implements NeutralMob {
         return bee;
     }
 
-    @Override
-    public int getHeadRotSpeed() {
-        return 1;
-    }
-
-    @Override
-    public int getMaxHeadXRot() {
-        return 90;
-    }
-
     public int getThrowCooldown() {
         return this.entityData.get(THROWCOOLDOWN);
     }


### PR DESCRIPTION
Heya! Is me again. I took a look at the rotation issue (#165) you requested help on. I'm by no means extremely versed in mod development these days, but this is the best I could do without modifying the Queen Bee's model or creating a mixin.

The issue seems to mostly stem from the Queen Bee not having a dedicated head in its model.

This solution only tries to turn towards the player's position every 20 ticks and stays locked on that position for the full duration. Minecraft waits 10 ticks for the head to be stable before rotating the body, then takes 10 ticks to rotate the body.

I had also experimented with manually updating the body rotation to match the head rotation in the queen bee's tick() function, but that looked pretty jittery compared to Minecraft's built-in body rotation handler.

It's possible there's a better solution, but this is the best I've got. Notably, it's not incredibly snappy and it'll rotate twice (the body will spin to accommodate the head for the first 40 degrees or so, then stop until the head is stable for 10 ticks) if the turn is far enough.

Also prevented the look location from updating if the player has moved less than 2 blocks so players can get a closer look at what she's holding without her spinning the item away from them.