### PR TITLE
Update teleport_projectiles.json

### DIFF
--- a/common/src/main/resources/data/the_bumblezone/tags/entity_types/dimension_teleportation/teleport_projectiles.json
+++ b/common/src/main/resources/data/the_bumblezone/tags/entity_types/dimension_teleportation/teleport_projectiles.json
@@ -23,6 +23,10 @@
       "required": false
     },
     {
+      "id": "endermanoverhaul:bubble_pearl",
+      "required": false
+    },
+    {
       "id": "endermanoverhaul:icy_pearl",
       "required": false
     },


### PR DESCRIPTION
A new bubble pearl _pops_ in!

Adds `endermanoverhaul:bubble_pearl` entity to the entity type tag relating to teleportation. I'm unsure if this mod's ender pearls are used in other tags, so I only edited this one.

[image](https://github.com/user-attachments/assets/f6bd309b-d986-4b18-8ed0-495bb43e4b5d)