### PR TITLE
Fix Lootr compatibility for 1.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,6 +158,7 @@ allprojects {
             url = 'https://maven.blamejared.com'
             content {
                 includeGroup 'mezz.jei'
+                includeGroup 'noobanidus.mods.lootr'
             }
         }
         maven {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -17,8 +17,7 @@ dependencies {
     modCompileOnly("me.shedaniel:RoughlyEnoughItems-api:${rootProject.rei}")
     modCompileOnly("me.shedaniel:RoughlyEnoughItems-default-plugin:${rootProject.rei}")
     modCompileOnly("me.shedaniel.cloth:cloth-config-fabric:${rootProject.cloth_config}")
-    modCompileOnly("curse.maven:lootr-361276:${project.lootr_file_id}")
-
+    modCompileOnly("noobanidus.mods.lootr:lootr-common:${rootProject.lootr_version}")
     modCompileOnly("maven.modrinth:projectile-damage-attribute:${rootProject.projectile_damage_attribute}-forge")
 }
 

--- a/common/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/LootrCompat.java
+++ b/common/src/main/java/com/telepathicgrunt/the_bumblezone/modcompat/LootrCompat.java
@@ -21,6 +21,7 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.Vec3;
 import noobanidus.mods.lootr.common.api.LootrAPI;
+import noobanidus.mods.lootr.common.api.data.DefaultLootFiller;
 import noobanidus.mods.lootr.common.api.data.ILootrInfoProvider;
 import noobanidus.mods.lootr.common.api.data.LootFiller;
 import org.apache.commons.lang3.NotImplementedException;
@@ -34,35 +35,7 @@ public class LootrCompat implements ModCompat {
 
     public static MenuProvider getCocoonMenu(ServerPlayer player, HoneyCocoonBlockEntity blockEntity) {
         ILootrInfoProvider iLootrInfoProvider = ILootrInfoProvider.of(blockEntity, blockEntity.getBlockEntityUuid());
-        return LootrAPI.getInventory(iLootrInfoProvider, player, new HoneyCocoonLootFiller(), LootrCompat::menuBuilder);
-    }
-
-    public static class HoneyCocoonLootFiller implements LootFiller {
-        @Override
-        public void unpackLootTable(@NotNull ILootrInfoProvider lootrInfoProvider, @NotNull Player player, Container container) {
-            if (lootrInfoProvider.getInfoContainer() instanceof HoneyCocoonBlockEntity honeyCocoonBlockEntity) {
-                if (lootrInfoProvider.getInfoLootTable() == null) {
-                    LootrAPI.LOG.error("Unable to fill loot cocoon in {} at {} as the loot table was null.", lootrInfoProvider.getInfoLevel().dimension(), honeyCocoonBlockEntity.getBlockPos());
-                    return;
-                }
-
-                if (lootrInfoProvider.getInfoLevel() instanceof ServerLevel serverLevel) {
-                    LootTable lootTable = serverLevel.getServer().reloadableRegistries().getLootTable(lootrInfoProvider.getInfoLootTable());
-                    if (lootTable == LootTable.EMPTY) {
-                        LootrAPI.LOG.error("Unable to fill loot cocoon in {} at {} as the loot table '{}' couldn't be resolved! Please search the loot table in `latest.log` to see if there are errors in loading.", serverLevel.dimension(), honeyCocoonBlockEntity.getBlockPos(), lootrInfoProvider.getInfoLootTable());
-                        return;
-                    }
-
-                    if (lootrInfoProvider.getInfoContainer() != null) {
-                        LootParams.Builder builder = (new LootParams.Builder((ServerLevel) lootrInfoProvider.getInfoLevel()).withParameter(LootContextParams.ORIGIN, Vec3.atCenterOf(honeyCocoonBlockEntity.getBlockPos())));
-                        builder.withLuck(player.getLuck()).withParameter(LootContextParams.THIS_ENTITY, player);
-                        honeyCocoonBlockEntity.setLootrInitialInventorySetting(true);
-                        lootTable.fill(honeyCocoonBlockEntity, builder.create(LootContextParamSets.CHEST), LootrAPI.getLootSeed(lootrInfoProvider.getInfoLootSeed()));
-                        honeyCocoonBlockEntity.setLootrInitialInventorySetting(false);
-                    }
-                }
-            }
-        }
+        return LootrAPI.getInventory(iLootrInfoProvider, player, DefaultLootFiller.getInstance(), LootrCompat::menuBuilder);
     }
 
     public static AbstractContainerMenu menuBuilder(int id, Inventory inventory, Container container, int rows) {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -32,8 +32,8 @@ dependencies {
     shadowCommon(project(path: ":common", configuration: "transformProductionFabric")) { transitive false }
 
     // COMPAT
-    modCompileOnly("curse.maven:lootr_fabric-615106:${project.lootr_fabric_file_id}")
-    //modRuntimeOnly("curse.maven:lootr_fabric-615106:${project.lootr_fabric_file_id}")
+    modCompileOnly("noobanidus.mods.lootr:lootr-fabric:${rootProject.lootr_version}")
+    //modRuntimeOnly("noobanidus.mods.lootr:lootr-fabric:${rootProject.lootr_version}")
 
     modCompileOnly("maven.modrinth:modmenu:${rootProject.mod_menu}")
     modRuntimeOnly("maven.modrinth:modmenu:${rootProject.mod_menu}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,13 +33,12 @@ quark=4.0-458
 zeta=1.0-19
 caelus_version=7.0.0+1.21
 geckolib_version=4.5.6
+lootr_version=1.21-1.10.34.88
 
 # Compat Dependencies using CurseMaven
 pokecubeaio_version=5133485
 productivebees_file_id=5555691
 buzzier_bees_file_id=5229011
-lootr_file_id=6108640
-lootr_fabric_file_id=6108639
 restricted_portals_file_id=5012474
 iron_jetpack_file_id=5398991
 pneumaticcraft_file_id=5321150

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -48,8 +48,9 @@ dependencies {
     modCompileOnly("curse.maven:productive_bees-377897:${project.productivebees_file_id}") { transitive = false }
 
     // modCompileOnly("curse.maven:corail_tombstone-243707:6171577")
-    modCompileOnly("curse.maven:lootr-361276:${project.lootr_file_id}")
-    modRuntimeOnly("curse.maven:lootr-361276:${project.lootr_file_id}")
+
+    modCompileOnly "noobanidus.mods.lootr:lootr-neoforge:${rootProject.lootr_version}"
+    //modRuntimeOnly("noobanidus.mods.lootr:lootr-neoforge:${rootProject.lootr_version}")
 
     modCompileOnly("curse.maven:pokecube_aio-285121:${project.pokecubeaio_version}") { transitive = false }
 


### PR DESCRIPTION
As noted on discord, this method relies on the "simple" compat style of `of(RandomizableContainerBlockEntity, UUID)`.

The LootrExampleMod has a much more extensive compatibility system that allows you to access the configuration (to retain block-breaking and block-hardness), as well as access to the "visual openers" system, refresh, decay, etc. 

Let me know if you'd like me to update the compatibility.

Unfortunately, I'm unable to get the Fabric version to launch due to missing `RenderAccess` (amongst other things). I'm not sure whether that's an issue with my build system or simply the current state of the repository, so I haven't dug too deeply into it.